### PR TITLE
add end of line detection for }} (DirectDefinition)

### DIFF
--- a/jkernel/jkernel.py
+++ b/jkernel/jkernel.py
@@ -158,7 +158,7 @@ class JKernel(Kernel):
         lastline = ''
         if len(lines) > 0:
             # Check last line (end of multiline statement)
-            if not lines[-1].strip() == ')':
+            if not lines[-1].strip() in [')','}}']:
                 lastline = lines[-1]
                 del lines[-1]
                 code = '\n'.join(lines)


### PR DESCRIPTION
This adds support for }} in multi-line
![image](https://user-images.githubusercontent.com/151573/148711212-e6ff2ae1-0199-4603-99fe-39af5f7e7751.png)

Without the fix
```
test2 =: {{
x+y
}}
```

```
|control error
|[-2] 
|control error
```

This can be tested here: https://mybinder.org/v2/gh/joebo/jkernel-docker/joebo
